### PR TITLE
freeze chart js version to workaround datetime format compatibility.

### DIFF
--- a/ice/assets/sample.properties
+++ b/ice/assets/sample.properties
@@ -14,7 +14,7 @@ ice.reservationPeriod=threeyear
 ice.reservationUtilization=MEDIUM
 
 # the highstock url; host it somewhere else and change this if you need HTTPS
-ice.highstockUrl=http://code.highcharts.com/stock/highstock.js
+ice.highstockUrl=https://code.highcharts.com/stock/4.2.1/highstock.js
 
 # url prefix, e.g. http://ice.netflix.com/. Will be used in alert emails.
 ice.urlPrefix=


### PR DESCRIPTION
See: https://github.com/Netflix/ice/issues/210
A breaking change has been made to the latest highstock.js file. Fixing the version to 4.2.1 appears to have worked-around the issue.