### PR TITLE
add ARG JAVA_OPTS to allow passing of proxy settings

### DIFF
--- a/ice/Dockerfile
+++ b/ice/Dockerfile
@@ -7,6 +7,8 @@ ENV GRAILS_VERSION 2.4.4
 ENV GRAILS_HOME ${HOME_DIR}/.grails/wrapper/${GRAILS_VERSION}/grails-${GRAILS_VERSION}
 ENV PATH $PATH:${HOME_DIR}/.grails/wrapper/${GRAILS_VERSION}/grails-${GRAILS_VERSION}/bin/
 
+ARG JAVA_OPTS
+
 WORKDIR ${HOME_DIR}
 
 # Install required software


### PR DESCRIPTION
Allows 'docker build' to work through a proxy with:

--build-arg=http_proxy=http://proxy.example.com:3128 --build-arg=https_proxy=http://proxy.example.com:3128 "--build-arg=JAVA_OPTS=-Dhttp.proxyHost=proxy.example.com -Dhttp.proxyPort=3128 -Dhttps.proxyHost=proxy.example.com -Dhttps.proxyPort=3128"